### PR TITLE
Add unit of measurement for temperature sensor 

### DIFF
--- a/HA_auto_mqtt.py
+++ b/HA_auto_mqtt.py
@@ -174,6 +174,7 @@ def init(SPAproducer):
     sensor_info = SensorInfoExtra(
         name="SPABoii.CurrentTemp",
         device_class="temperature",
+        unit_of_measurement="°F",
         unique_id="spa_temp_sensor",
         suggested_display_precision=0,
     )


### PR DESCRIPTION
Deals with error in HA stating "none" is not a valid unit of measurement for device_class temperature.